### PR TITLE
Removed tainting - deprecated in 2.7 and removed in Ruby 3.0

### DIFF
--- a/ext/rbsrt/rbsrt.c
+++ b/ext/rbsrt/rbsrt.c
@@ -882,7 +882,6 @@ VALUE rbsrt_socket_recvmsg(VALUE self)
 
     VALUE data = rb_str_buf_new((long)nbytes);
     rb_str_buf_cat(data, buf, (long)nbytes);
-    rb_obj_taint(data);
 
     return data;
 }
@@ -1012,7 +1011,6 @@ VALUE rbsrt_socket_get_streamid(VALUE self)
 
     VALUE result = rb_str_buf_new((long)streamid_len);
     rb_str_buf_cat(result, streamid, (long)streamid_len);
-    rb_obj_taint(result);
 
     return result;
 }


### PR DESCRIPTION
Removed calls to rb_obj_taint as tainting has been deprecated in Ruby 2.7 and the API removed in Ruby 3.0